### PR TITLE
[RDSS-955] Allow sleep interval to be customised

### DIFF
--- a/rdsslib/kinesis/factory.py
+++ b/rdsslib/kinesis/factory.py
@@ -8,7 +8,7 @@ from .reader import StreamReader
 from .writer import StreamWriter
 
 
-def kinesis_client_factory(client_type):
+def kinesis_client_factory(client_type, read_interval=0.2):
     """ Create customised instances of KinesisClient or its subclasses
     :param client_type: Specifies the type of client that the factory
                         should construct
@@ -17,7 +17,7 @@ def kinesis_client_factory(client_type):
     """
     boto_client = boto3.client('kinesis')
     writer = StreamWriter(client=boto_client)
-    reader = StreamReader(client=boto_client)
+    reader = StreamReader(client=boto_client, read_interval=read_interval)
 
     if client_type == 'basic':
         return KinesisClient(writer=writer,

--- a/rdsslib/kinesis/reader.py
+++ b/rdsslib/kinesis/reader.py
@@ -2,13 +2,14 @@ import time
 
 
 class StreamReader(object):
-    def __init__(self, client):
+    def __init__(self, client, read_interval):
         """
         Boto3 abstraction that reads from a Kinesis stream
         :param client: An instance of boto3 kinesis client
         :type client: botocore.client.Kinesis
         """
         self.client = client
+        self.read_interval = read_interval
 
     def read_stream(self, stream_name, seq_number=None):
         """Listen for messages from a stream and yield response.
@@ -34,7 +35,7 @@ class StreamReader(object):
             for record in records:
                 yield record
 
-            time.sleep(0.2)
+            time.sleep(self.read_interval)
             iterator = response['NextShardIterator']
 
     def _get_shard_id(self, stream_name):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,8 +1,14 @@
 import boto3
 import json
 from .kinesis_helpers import KinesisMixin
+from moto import (
+    mock_kinesis,
+)
 import pytest
 from rdsslib.kinesis import reader
+from unittest.mock import (
+    patch,
+)
 
 
 class TestStreamReader(KinesisMixin):
@@ -13,7 +19,7 @@ class TestStreamReader(KinesisMixin):
         return boto3.client('kinesis')
 
     def test_read_stream_returns_message(self, serialised_payload, client):
-        s_reader = reader.StreamReader(client=client)
+        s_reader = reader.StreamReader(client=client, read_interval=0.2)
         s_reader.client.create_stream(StreamName='test_stream', ShardCount=1)
         s_reader.client.put_record(StreamName='test_stream',
                                    Data=serialised_payload,
@@ -22,3 +28,34 @@ class TestStreamReader(KinesisMixin):
         msg = next(record_gen)
         decoded = json.loads(msg['Data'].decode('utf-8'))
         assert decoded['messageBody'] == {'some': 'message'}
+
+    @mock_kinesis
+    def test_read_interval_respected(self):
+        stream_name = 'test-stream'
+        kinesis_client = boto3.client('kinesis', region_name='us-east-1')
+        kinesis_client.create_stream(StreamName=stream_name, ShardCount=1)
+        kinesis_client.put_record(
+            StreamName=stream_name,
+            PartitionKey=stream_name,
+            Data=json.dumps({'some': 'data'})
+        )
+        s_reader = reader.StreamReader(client=kinesis_client, read_interval=20)
+        records = s_reader.read_stream(stream_name)
+
+        seconds_slept = None
+
+        # The production code is in an infinite loop of sleeps, so we patch
+        # sleep to throw an exception to get out of it in the test
+        def mock_sleep(seconds):
+            nonlocal seconds_slept
+            seconds_slept = seconds
+            raise Exception()
+
+        next(records)
+        with patch('time.sleep', side_effect=mock_sleep):
+            try:
+                next(records)
+            except Exception:
+                pass
+
+        assert seconds_slept == 20


### PR DESCRIPTION
When creating the Arkivum Adapter, which reads from the Kinesis streams
shared_services_output_*, when it reached the most recent messages, it
would raise the exception

    botocore.errorfactory.ProvisionedThroughputExceededException: An
    error occurred (ProvisionedThroughputExceededException) when calling
    the GetRecords operation: Rate exceeded for shard
    shardId-000000000000 in stream shared_services_output_dev under
    account 458323522494

The interval of 0.2 does appear to respect the limit at
https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html

    Each shard can support up to 5 transactions per second for reads

However, this only hold when there is 1 client per stream: I suspect
there are now at least 2 readers of the shared_services_output stream. I
suspect Kinesis is not designed for this case: multiple independent
consumers of a stream. Some longer term architectural descisions have to
be made in this respect: and this is a short term attempt to try to
avoid the exception.