### PR TITLE
[RDSS-955] Fetch just after the sequence number requested

### DIFF
--- a/rdsslib/kinesis/reader.py
+++ b/rdsslib/kinesis/reader.py
@@ -67,7 +67,7 @@ class StreamReader(object):
             response = self.client.get_shard_iterator(
                 StreamName=stream_name,
                 ShardId=shard_id,
-                ShardIteratorType='AT_SEQUENCE_NUMBER',
+                ShardIteratorType='AFTER_SEQUENCE_NUMBER',
                 StartingSequenceNumber=seq_number
             )
         return response['ShardIterator']


### PR DESCRIPTION
This could be a breaking change depending on how clients use it.
However, they should(?) be saving sequence numbers that they have
processed, and so should not need to have returned that record.