### PR TITLE
Feature/rdss 1556 add shared library to content based router

### DIFF
--- a/rdsslib/kinesis/client.py
+++ b/rdsslib/kinesis/client.py
@@ -130,4 +130,4 @@ class EnhancedKinesisClient(KinesisClient):
         :param error_code: Error Code
         :param error_description: Description Of Error
         """
-        self.error_handler.handle_error(payload,error_code,error_description)
+        self.error_handler.handle_error(payload, error_code, error_description)

--- a/rdsslib/kinesis/client.py
+++ b/rdsslib/kinesis/client.py
@@ -98,6 +98,8 @@ class EnhancedKinesisClient(KinesisClient):
             json.loads(payload)
         except json.decoder.JSONDecodeError:
             self.error_handler.handle_invalid_json(payload)
+            return
+
         decorated_payload = self._apply_decorators(payload)
         for stream_name in stream_names:
             try:

--- a/rdsslib/kinesis/client.py
+++ b/rdsslib/kinesis/client.py
@@ -122,3 +122,12 @@ class EnhancedKinesisClient(KinesisClient):
                 self.error_handler.handle_invalid_json(payload)
         else:
             self.error_handler.handle_invalid_json(payload)
+
+    def handle_error(self, payload, error_code, error_description):
+        """ Allows errors to be posted to the stream occurring from
+        activities like payload validation
+        :param payload: JSON payload
+        :param error_code: Error Code
+        :param error_description: Description Of Error
+        """
+        self.error_handler.handle_error(payload,error_code,error_description)

--- a/rdsslib/kinesis/client.py
+++ b/rdsslib/kinesis/client.py
@@ -101,15 +101,18 @@ class EnhancedKinesisClient(KinesisClient):
         decorated_payload = self._apply_decorators(payload)
         for stream_name in stream_names:
             try:
-                super().write_message([stream_name], decorated_payload,
+                super().write_message([stream_name],
+                                      decorated_payload,
                                       max_attempts)
             except MaxRetriesExceededException as e:
                 stream_name = e.args[0]
                 error_code = 'GENERR005'
                 error_description = 'Maximum retry attempts {0} exceed'\
-                    'for stream {1}'.format(max_attempts, stream_name)
-                self.error_handler.handle_error(
-                    decorated_payload, error_code, error_description)
+                    'for stream {1}'.format(max_attempts,
+                                            stream_name)
+                self.error_handler.handle_error(decorated_payload,
+                                                error_code,
+                                                error_description)
 
     def handle_error(self, payload, error_code, error_description):
         """ Allows errors to be posted to the stream occurring from
@@ -119,7 +122,3 @@ class EnhancedKinesisClient(KinesisClient):
         :param error_description: Description Of Error
         """
         self.error_handler.handle_error(payload, error_code, error_description)
-
-
-
-

--- a/tests/kinesis/test_handlers.py
+++ b/tests/kinesis/test_handlers.py
@@ -1,4 +1,7 @@
 import json
+
+from rdsslib.kinesis.client import EnhancedKinesisClient
+
 from .kinesis_helpers import MockStreamWriter
 import pytest
 from rdsslib.kinesis import handlers
@@ -33,5 +36,13 @@ class TestMessageErrorHandler(object):
     def test_error_handling_with_valid_json(self, serialised_payload):
         self.handler.handle_error(
             serialised_payload, 'ERROR', 'Error occurred')
+        payload = self.mock_writer.streams['error_stream'][0]
+        assert json.loads(payload)['messageBody'] == {'some': 'message'}
+
+    def test_error_handling_from_client_with_valid_json(self, serialised_payload):
+        mock_client = EnhancedKinesisClient(None, None, self.handler, None)
+        mock_client.handle_error(payload=serialised_payload,
+                                 error_code='TESTERR001',
+                                 error_description='Generated Test Message to Error')
         payload = self.mock_writer.streams['error_stream'][0]
         assert json.loads(payload)['messageBody'] == {'some': 'message'}

--- a/tests/kinesis/test_handlers.py
+++ b/tests/kinesis/test_handlers.py
@@ -45,9 +45,9 @@ class TestMessageErrorHandler(object):
                                             None,
                                             self.handler,
                                             None)
+        error = 'Generated Test Message to Error'
         mock_client.handle_error(payload=serialised_payload,
                                  error_code='TESTERR001',
-                                 error_description=
-                                    'Generated Test Message to Error')
+                                 error_description=error)
         payload = self.mock_writer.streams['error_stream'][0]
         assert json.loads(payload)['messageBody'] == {'some': 'message'}

--- a/tests/kinesis/test_handlers.py
+++ b/tests/kinesis/test_handlers.py
@@ -1,10 +1,9 @@
 import json
-
-from rdsslib.kinesis.client import EnhancedKinesisClient
-
-from .kinesis_helpers import MockStreamWriter
 import pytest
+
+from rdsslib.kinesis.client import EnhancedKinesisClient, handlers
 from rdsslib.kinesis import handlers
+from .kinesis_helpers import MockStreamWriter
 
 
 class TestMessageErrorHandler(object):

--- a/tests/kinesis/test_handlers.py
+++ b/tests/kinesis/test_handlers.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 
-from rdsslib.kinesis.client import EnhancedKinesisClient, handlers
+from rdsslib.kinesis.client import EnhancedKinesisClient
 from rdsslib.kinesis import handlers
 from .kinesis_helpers import MockStreamWriter
 

--- a/tests/kinesis/test_handlers.py
+++ b/tests/kinesis/test_handlers.py
@@ -39,10 +39,15 @@ class TestMessageErrorHandler(object):
         payload = self.mock_writer.streams['error_stream'][0]
         assert json.loads(payload)['messageBody'] == {'some': 'message'}
 
-    def test_error_handling_from_client_with_valid_json(self, serialised_payload):
-        mock_client = EnhancedKinesisClient(None, None, self.handler, None)
+    def test_error_handling_from_client_with_valid_json(self,
+                                                        serialised_payload):
+        mock_client = EnhancedKinesisClient(None,
+                                            None,
+                                            self.handler,
+                                            None)
         mock_client.handle_error(payload=serialised_payload,
                                  error_code='TESTERR001',
-                                 error_description='Generated Test Message to Error')
+                                 error_description=
+                                    'Generated Test Message to Error')
         payload = self.mock_writer.streams['error_stream'][0]
         assert json.loads(payload)['messageBody'] == {'some': 'message'}


### PR DESCRIPTION
Addition of a method and unit tests to the client object.  Allows the client object to write messages to the client's error stream.